### PR TITLE
fix: add friendly 404 pages for missing owner and pet

### DIFF
--- a/e2e-tests/tests/features/not-found.spec.ts
+++ b/e2e-tests/tests/features/not-found.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@fixtures/base-test';
+
+test.describe('Friendly 404 pages', () => {
+  test('navigating to a non-existent owner shows 404 page with friendly message', async ({ page }) => {
+    const response = await page.goto('/owners/99999');
+
+    // Verify HTTP 404 status
+    expect(response?.status()).toBe(404);
+
+    // Verify friendly heading is shown (not a stack trace)
+    await expect(page.getByRole('heading', { level: 2 })).toBeVisible();
+
+    // Verify "Find Owners" link is present in the error card (in addition to nav)
+    await expect(page.locator('.liatrio-error-card').getByRole('link', { name: /Find Owners/i })).toBeVisible();
+
+    // Verify no internal exception details are exposed
+    const bodyText = await page.locator('body').textContent();
+    expect(bodyText).not.toContain('IllegalArgumentException');
+    expect(bodyText).not.toContain('at org.springframework');
+    expect(bodyText).not.toContain('Owner not found with id');
+  });
+
+  test('Find Owners link on 404 page navigates to owner search', async ({ page }) => {
+    await page.goto('/owners/99999');
+
+    // Click Find Owners link and verify navigation
+    await page.getByRole('link', { name: /Find Owners/i }).first().click();
+    await expect(page).toHaveURL(/\/owners\/find/);
+  });
+});

--- a/e2e-tests/tests/features/not-found.spec.ts
+++ b/e2e-tests/tests/features/not-found.spec.ts
@@ -8,7 +8,7 @@ test.describe('Friendly 404 pages', () => {
     expect(response?.status()).toBe(404);
 
     // Verify friendly heading is shown (not a stack trace)
-    await expect(page.getByRole('heading', { level: 2 })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 2 })).toContainText(/something happened/i);
 
     // Verify "Find Owners" link is present in the error card (in addition to nav)
     await expect(page.locator('.liatrio-error-card').getByRole('link', { name: /Find Owners/i })).toBeVisible();

--- a/src/main/java/org/springframework/samples/petclinic/system/ExceptionHandlerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/ExceptionHandlerAdvice.java
@@ -28,9 +28,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ControllerAdvice
 class ExceptionHandlerAdvice {
 
-	@ExceptionHandler(IllegalArgumentException.class)
+	@ExceptionHandler({ IllegalArgumentException.class, ResourceNotFoundException.class })
 	@ResponseStatus(HttpStatus.NOT_FOUND)
-	public String handleIllegalArgument(IllegalArgumentException ex, Model model) {
+	public String handleNotFound(RuntimeException ex, Model model) {
 		model.addAttribute("status", HttpStatus.NOT_FOUND.value());
 		return "error";
 	}

--- a/src/main/java/org/springframework/samples/petclinic/system/ExceptionHandlerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/ExceptionHandlerAdvice.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.system;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Global exception handler that provides friendly error pages for known error conditions.
+ * Avoids exposing internal exception details or stack traces to users.
+ */
+@ControllerAdvice
+class ExceptionHandlerAdvice {
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public String handleIllegalArgument(IllegalArgumentException ex, Model model) {
+		model.addAttribute("status", HttpStatus.NOT_FOUND.value());
+		return "error";
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/system/ResourceNotFoundException.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/ResourceNotFoundException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.system;
+
+/**
+ * Exception thrown when a requested resource cannot be found. Semantically clearer than
+ * {@link IllegalArgumentException} for missing-resource scenarios.
+ */
+public class ResourceNotFoundException extends RuntimeException {
+
+	public ResourceNotFoundException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -15,7 +15,11 @@
         <span th:case="*" th:text="#{error.general}">An unexpected error occurred.</span>
       </p>
 
-      <p class="liatrio-muted" th:text="${message}">Exception message</p>
+      <p class="liatrio-muted" th:if="${message}" th:text="${message}">Exception message</p>
+
+      <p>
+        <a th:href="@{/owners/find}" th:text="#{findOwners}">Find Owners</a>
+      </p>
     </div>
   </section>
 </body>

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -229,6 +229,12 @@ class OwnerControllerTests {
 	}
 
 	@Test
+	void testShowOwnerNotFound() throws Exception {
+		given(this.owners.findById(99)).willReturn(Optional.empty());
+		mockMvc.perform(get("/owners/{ownerId}", 99)).andExpect(status().isNotFound());
+	}
+
+	@Test
 	public void testProcessUpdateOwnerFormWithIdMismatch() throws Exception {
 		int pathOwnerId = 1;
 

--- a/src/test/java/org/springframework/samples/petclinic/owner/VisitControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/VisitControllerTests.java
@@ -91,4 +91,18 @@ class VisitControllerTests {
 			.andExpect(view().name("pets/createOrUpdateVisitForm"));
 	}
 
+	@Test
+	void testInitNewVisitFormOwnerNotFound() throws Exception {
+		given(this.owners.findById(99)).willReturn(Optional.empty());
+		mockMvc.perform(get("/owners/{ownerId}/pets/{petId}/visits/new", 99, TEST_PET_ID))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void testInitNewVisitFormPetNotFound() throws Exception {
+		given(this.owners.findById(TEST_OWNER_ID)).willReturn(Optional.of(new Owner()));
+		mockMvc.perform(get("/owners/{ownerId}/pets/{petId}/visits/new", TEST_OWNER_ID, 99))
+			.andExpect(status().isNotFound());
+	}
+
 }

--- a/src/test/java/org/springframework/samples/petclinic/system/ExceptionHandlerAdviceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/ExceptionHandlerAdviceTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.system;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.aot.DisabledInAotMode;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Test class for {@link ExceptionHandlerAdvice}.
+ */
+@WebMvcTest({ ExceptionHandlerAdvice.class, ExceptionHandlerAdviceTests.TestController.class })
+@DisabledInNativeImage
+@DisabledInAotMode
+class ExceptionHandlerAdviceTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void handleIllegalArgumentReturnsNotFoundStatus() throws Exception {
+		mockMvc.perform(get("/test/illegal-argument")).andExpect(status().isNotFound());
+	}
+
+	@Test
+	void handleIllegalArgumentDoesNotExposeExceptionMessage() throws Exception {
+		String responseBody = mockMvc.perform(get("/test/illegal-argument"))
+			.andExpect(status().isNotFound())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		org.assertj.core.api.Assertions.assertThat(responseBody)
+			.doesNotContain("Internal entity details that should not be exposed");
+	}
+
+	@RestController
+	@RequestMapping("/test")
+	static class TestController {
+
+		@GetMapping("/illegal-argument")
+		public String throwIllegalArgument() {
+			throw new IllegalArgumentException("Internal entity details that should not be exposed");
+		}
+
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/system/ExceptionHandlerAdviceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/ExceptionHandlerAdviceTests.java
@@ -58,6 +58,23 @@ class ExceptionHandlerAdviceTests {
 			.doesNotContain("Internal entity details that should not be exposed");
 	}
 
+	@Test
+	void handleResourceNotFoundExceptionReturnsNotFoundStatus() throws Exception {
+		mockMvc.perform(get("/test/resource-not-found")).andExpect(status().isNotFound());
+	}
+
+	@Test
+	void handleResourceNotFoundExceptionDoesNotExposeExceptionMessage() throws Exception {
+		String responseBody = mockMvc.perform(get("/test/resource-not-found"))
+			.andExpect(status().isNotFound())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		org.assertj.core.api.Assertions.assertThat(responseBody)
+			.doesNotContain("Resource details that should not be exposed");
+	}
+
 	@RestController
 	@RequestMapping("/test")
 	static class TestController {
@@ -65,6 +82,11 @@ class ExceptionHandlerAdviceTests {
 		@GetMapping("/illegal-argument")
 		public String throwIllegalArgument() {
 			throw new IllegalArgumentException("Internal entity details that should not be exposed");
+		}
+
+		@GetMapping("/resource-not-found")
+		public String throwResourceNotFound() {
+			throw new ResourceNotFoundException("Resource details that should not be exposed");
 		}
 
 	}


### PR DESCRIPTION
## Summary

- Creates `ExceptionHandlerAdvice` (`@ControllerAdvice`) in the `system` package that catches `IllegalArgumentException` thrown by controllers (e.g., missing owner or pet lookups) and returns HTTP 404 with the `error` view — without exposing raw exception details or stack traces to users.
- Updates `error.html` to include a **"Find Owners"** link in the error card (using the existing `#{findOwners}` i18n key), and makes the `${message}` display conditional so it only shows when explicitly set (preventing accidental exposure of internal details).
- Adds JUnit MVC tests asserting 404 status for missing owner (`OwnerControllerTests`), missing owner on visit form, and missing pet on visit form (`VisitControllerTests`), plus dedicated `ExceptionHandlerAdviceTests`.
- Adds a Playwright E2E spec (`not-found.spec.ts`) verifying 404 HTTP status, friendly message, and "Find Owners" link for a non-existent owner URL.

## Test plan

- [x] `./mvnw spring-javaformat:apply` run before every test execution
- [x] `OwnerControllerTests#testShowOwnerNotFound` — asserts HTTP 404 for `/owners/99`
- [x] `VisitControllerTests#testInitNewVisitFormOwnerNotFound` — asserts HTTP 404 for missing owner
- [x] `VisitControllerTests#testInitNewVisitFormPetNotFound` — asserts HTTP 404 for missing pet
- [x] `ExceptionHandlerAdviceTests` — direct unit test of the advice; asserts no message leakage
- [x] Full test suite: **64 tests pass, 0 failures** (including existing `CrashControllerIntegrationTests`)
- [x] Playwright E2E: `navigating to a non-existent owner shows 404 page with friendly message` — **PASSED**
- [x] Playwright E2E: `Find Owners link on 404 page navigates to owner search` — **PASSED**

## Proof of Issue #10 requirements

- **Playwright**: Navigated to `/owners/99999` (non-existent), verified HTTP 404 status, friendly heading visible, "Find Owners" link present in the error card, no `IllegalArgumentException` or stack trace text in page body.
- **JUnit**: MVC tests assert 404 status for missing owner (`testShowOwnerNotFound`) and missing pet (`testInitNewVisitFormPetNotFound`).

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User-friendly 404 error page with a clear heading and a "Find Owners" link to return to owner search.

* **Bug Fixes**
  * Missing resources now return proper 404 responses and do not expose internal exception details.

* **Tests**
  * Added unit, integration, and end-to-end tests verifying 404 status, hidden error details, and navigation from the 404 page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->