### PR TITLE
feat: add upcoming visits page at /visits/upcoming

### DIFF
--- a/e2e-tests/tests/features/upcoming-visits.spec.ts
+++ b/e2e-tests/tests/features/upcoming-visits.spec.ts
@@ -38,6 +38,6 @@ test.describe('Upcoming Visits page', () => {
   test('respects days query parameter', async ({ page }) => {
     const response = await page.goto('/visits/upcoming?days=14');
     expect(response?.status()).toBe(200);
-    await expect(page.getByText(/14/)).toBeVisible();
+    await expect(page.locator('.liatrio-muted')).toContainText('14');
   });
 });

--- a/e2e-tests/tests/features/upcoming-visits.spec.ts
+++ b/e2e-tests/tests/features/upcoming-visits.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@fixtures/base-test';
+
+test.describe('Upcoming Visits page', () => {
+  test('page renders at /visits/upcoming', async ({ page }) => {
+    const response = await page.goto('/visits/upcoming');
+    expect(response?.status()).toBe(200);
+    await expect(page.getByRole('heading', { name: /Upcoming Visits/i })).toBeVisible();
+  });
+
+  test('creates a visit and verifies it appears in upcoming list', async ({ page }) => {
+    // Use a date 2 days from now so it falls in the default 7-day window
+    const today = new Date();
+    const futureDate = new Date(today);
+    futureDate.setDate(today.getDate() + 2);
+    const yyyy = futureDate.getFullYear();
+    const mm = String(futureDate.getMonth() + 1).padStart(2, '0');
+    const dd = String(futureDate.getDate()).padStart(2, '0');
+    const visitDate = `${yyyy}-${mm}-${dd}`;
+
+    // Owner 1 (George Franklin), Pet 1 (Leo) exists in seed data
+    await page.goto('/owners/1/pets/1/visits/new');
+    await page.locator('input#date').fill(visitDate);
+    await page.locator('input#description').fill('E2E Upcoming Visit Test');
+    await page.getByRole('button', { name: /Add Visit/i }).click();
+
+    // Verify redirect back to owner
+    await expect(page).toHaveURL(/\/owners\/1/);
+
+    // Navigate to upcoming visits
+    await page.goto('/visits/upcoming');
+    await expect(page.getByRole('heading', { name: /Upcoming Visits/i })).toBeVisible();
+
+    // Verify the visit appears
+    await expect(page.getByText('E2E Upcoming Visit Test')).toBeVisible();
+    await expect(page.getByText(visitDate)).toBeVisible();
+  });
+
+  test('respects days query parameter', async ({ page }) => {
+    const response = await page.goto('/visits/upcoming?days=14');
+    expect(response?.status()).toBe(200);
+    await expect(page.getByText(/14/)).toBeVisible();
+  });
+});

--- a/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
@@ -82,6 +82,11 @@ public class Pet extends NamedEntity {
 		return this.owner;
 	}
 
+	/**
+	 * Sets the owner reference for in-memory access and testing only. This field is
+	 * read-only at the JPA level (insertable = false, updatable = false); changes will
+	 * not be persisted to the database.
+	 */
 	public void setOwner(Owner owner) {
 		this.owner = owner;
 	}

--- a/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
@@ -53,6 +53,10 @@ public class Pet extends NamedEntity {
 	@JoinColumn(name = "type_id")
 	private PetType type;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "owner_id", insertable = false, updatable = false)
+	private Owner owner;
+
 	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
 	@JoinColumn(name = "pet_id")
 	@OrderBy("date ASC")
@@ -72,6 +76,14 @@ public class Pet extends NamedEntity {
 
 	public void setType(PetType type) {
 		this.type = type;
+	}
+
+	public Owner getOwner() {
+		return this.owner;
+	}
+
+	public void setOwner(Owner owner) {
+		this.owner = owner;
 	}
 
 	public Collection<Visit> getVisits() {

--- a/src/main/java/org/springframework/samples/petclinic/owner/UpcomingVisitView.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/UpcomingVisitView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.owner;
+
+import java.time.LocalDate;
+
+/**
+ * Read-only view record for displaying upcoming visit information. Encapsulates visit
+ * date, description, pet name, and owner name into a single transferable object.
+ */
+public record UpcomingVisitView(LocalDate date, String description, String petName, String ownerFirstName,
+		String ownerLastName) {
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/UpcomingVisitsController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/UpcomingVisitsController.java
@@ -39,6 +39,12 @@ class UpcomingVisitsController {
 
 	@GetMapping("/visits/upcoming")
 	public String upcomingVisits(@RequestParam(defaultValue = "7") int days, Model model) {
+		if (days < 1) {
+			days = 7;
+		}
+		else if (days > 365) {
+			days = 365;
+		}
 		LocalDate today = LocalDate.now();
 		List<Visit> rawVisits = this.visits.findUpcomingWithPetAndOwner(today, today.plusDays(days));
 		List<UpcomingVisitView> viewList = rawVisits.stream()

--- a/src/main/java/org/springframework/samples/petclinic/owner/UpcomingVisitsController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/UpcomingVisitsController.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.owner;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Controller for the read-only upcoming visits page at {@code /visits/upcoming}. Displays
+ * visits scheduled within the next N days (default 7).
+ */
+@Controller
+class UpcomingVisitsController {
+
+	private final VisitRepository visits;
+
+	UpcomingVisitsController(VisitRepository visits) {
+		this.visits = visits;
+	}
+
+	@GetMapping("/visits/upcoming")
+	public String upcomingVisits(@RequestParam(defaultValue = "7") int days, Model model) {
+		LocalDate today = LocalDate.now();
+		List<Visit> rawVisits = this.visits.findUpcomingWithPetAndOwner(today, today.plusDays(days));
+		List<UpcomingVisitView> viewList = rawVisits.stream()
+			.map(v -> new UpcomingVisitView(v.getDate(), v.getDescription(), v.getPet().getName(),
+					v.getPet().getOwner().getFirstName(), v.getPet().getOwner().getLastName()))
+			.toList();
+		model.addAttribute("visits", viewList);
+		model.addAttribute("days", days);
+		return "visits/upcomingVisits";
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/Visit.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Visit.java
@@ -22,6 +22,9 @@ import org.springframework.samples.petclinic.model.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 
@@ -41,6 +44,10 @@ public class Visit extends BaseEntity {
 
 	@NotBlank
 	private String description;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "pet_id", insertable = false, updatable = false)
+	private Pet pet;
 
 	/**
 	 * Creates a new instance of Visit for the current date
@@ -63,6 +70,14 @@ public class Visit extends BaseEntity {
 
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	public Pet getPet() {
+		return this.pet;
+	}
+
+	public void setPet(Pet pet) {
+		this.pet = pet;
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitRepository.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.owner;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Repository interface for {@link Visit} entities. Provides a query for fetching upcoming
+ * visits with their associated pet and owner data eagerly loaded to avoid N+1 queries.
+ */
+public interface VisitRepository extends JpaRepository<Visit, Integer> {
+
+	@Query("SELECT v FROM Visit v JOIN FETCH v.pet p JOIN FETCH p.owner o "
+			+ "WHERE v.date BETWEEN :startDate AND :endDate ORDER BY v.date ASC")
+	List<Visit> findUpcomingWithPetAndOwner(@Param("startDate") LocalDate startDate,
+			@Param("endDate") LocalDate endDate);
+
+}

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -63,3 +63,7 @@ home.pets.alt=Pets at the clinic
 home.findOwners.help=Search by last name to locate an owner record.
 vets.subtitle=A snapshot of the care team and specialties.
 layout.footer.logo.alt=Emerald Grove Veterinary Clinic logo
+upcomingVisits=Upcoming Visits
+upcomingVisits.subtitle=Showing visits for the next
+upcomingVisits.days=day(s)
+upcomingVisits.noResults=No upcoming visits found.

--- a/src/main/resources/messages/messages_de.properties
+++ b/src/main/resources/messages/messages_de.properties
@@ -63,3 +63,7 @@ home.pets.alt=Haustiere in der Klinik
 home.findOwners.help=Nach Nachnamen suchen, um einen Besitzerdatensatz zu finden.
 vets.subtitle=Ein Überblick über das Behandlungsteam und die Fachgebiete.
 layout.footer.logo.alt=Logo von Emerald Grove Veterinary Clinic
+upcomingVisits=Bevorstehende Besuche
+upcomingVisits.subtitle=Besuche für die nächsten
+upcomingVisits.days=Tag(e) anzeigen
+upcomingVisits.noResults=Keine bevorstehenden Besuche gefunden.

--- a/src/main/resources/messages/messages_es.properties
+++ b/src/main/resources/messages/messages_es.properties
@@ -63,3 +63,7 @@ home.pets.alt=Mascotas en la clínica
 home.findOwners.help=Busca por apellido para localizar un registro de propietario.
 vets.subtitle=Una instantánea del equipo de atención y sus especialidades.
 layout.footer.logo.alt=Logotipo de Emerald Grove Veterinary Clinic
+upcomingVisits=Próximas visitas
+upcomingVisits.subtitle=Mostrando visitas para los próximos
+upcomingVisits.days=día(s)
+upcomingVisits.noResults=No se encontraron próximas visitas.

--- a/src/main/resources/messages/messages_fa.properties
+++ b/src/main/resources/messages/messages_fa.properties
@@ -63,3 +63,7 @@ home.pets.alt=حیوانات در کلینیک
 home.findOwners.help=برای یافتن پروندهٔ صاحب، با نام خانوادگی جستجو کنید.
 vets.subtitle=نمایی از تیم درمان و تخصص‌ها.
 layout.footer.logo.alt=لوگوی Emerald Grove Veterinary Clinic
+upcomingVisits=ویزیت‌های آینده
+upcomingVisits.subtitle=نمایش ویزیت‌های
+upcomingVisits.days=روز آینده
+upcomingVisits.noResults=هیچ ویزیت آینده‌ای یافت نشد.

--- a/src/main/resources/messages/messages_ko.properties
+++ b/src/main/resources/messages/messages_ko.properties
@@ -63,3 +63,7 @@ home.pets.alt=클리닉의 반려동물
 home.findOwners.help=성으로 검색하여 보호자 기록을 찾으세요.
 vets.subtitle=진료 팀과 전문 분야를 한눈에 볼 수 있습니다.
 layout.footer.logo.alt=Emerald Grove Veterinary Clinic 로고
+upcomingVisits=예정된 방문
+upcomingVisits.subtitle=다음 기간의 방문을 표시합니다
+upcomingVisits.days=일
+upcomingVisits.noResults=예정된 방문이 없습니다.

--- a/src/main/resources/messages/messages_pt.properties
+++ b/src/main/resources/messages/messages_pt.properties
@@ -63,3 +63,7 @@ home.pets.alt=Pets na clínica
 home.findOwners.help=Pesquise pelo sobrenome para localizar um registro de proprietário.
 vets.subtitle=Um panorama da equipe de atendimento e das especialidades.
 layout.footer.logo.alt=Logotipo da Emerald Grove Veterinary Clinic
+upcomingVisits=Próximas visitas
+upcomingVisits.subtitle=Mostrando visitas para os próximos
+upcomingVisits.days=dia(s)
+upcomingVisits.noResults=Nenhuma visita futura encontrada.

--- a/src/main/resources/messages/messages_ru.properties
+++ b/src/main/resources/messages/messages_ru.properties
@@ -63,3 +63,7 @@ home.pets.alt=Питомцы в клинике
 home.findOwners.help=Ищите по фамилии, чтобы найти запись владельца.
 vets.subtitle=Краткий обзор команды ухода и специализаций.
 layout.footer.logo.alt=Логотип Emerald Grove Veterinary Clinic
+upcomingVisits=Предстоящие визиты
+upcomingVisits.subtitle=Показаны визиты на следующие
+upcomingVisits.days=дн.
+upcomingVisits.noResults=Предстоящих визитов не найдено.

--- a/src/main/resources/messages/messages_tr.properties
+++ b/src/main/resources/messages/messages_tr.properties
@@ -63,3 +63,7 @@ home.pets.alt=Klinikteki evcil hayvanlar
 home.findOwners.help=Bir sahip kaydını bulmak için soyada göre arayın.
 vets.subtitle=Bakım ekibi ve uzmanlıkların kısa bir özeti.
 layout.footer.logo.alt=Emerald Grove Veterinary Clinic logosu
+upcomingVisits=Yaklaşan Ziyaretler
+upcomingVisits.subtitle=Sonraki günlerin ziyaretleri gösteriliyor
+upcomingVisits.days=gün
+upcomingVisits.noResults=Yaklaşan ziyaret bulunamadı.

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -59,6 +59,11 @@
             <span th:text="#{vets}">Veterinarians</span>
           </li>
 
+          <li th:replace="~{::menuItem ('/visits/upcoming','visits','upcoming visits','calendar',#{upcomingVisits})}">
+            <span class="fa fa-calendar" aria-hidden="true"></span>
+            <span th:text="#{upcomingVisits}">Upcoming Visits</span>
+          </li>
+
           <li
             th:replace="~{::menuItem ('/oups','error','trigger a RuntimeException to see how it is handled','exclamation-triangle',#{error})}">
             <span class="fa exclamation-triangle" aria-hidden="true"></span>

--- a/src/main/resources/templates/visits/upcomingVisits.html
+++ b/src/main/resources/templates/visits/upcomingVisits.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+
+<html xmlns:th="https://www.thymeleaf.org" th:replace="~{fragments/layout :: layout (~{::body},'visits')}">
+
+<body>
+
+  <section class="liatrio-section">
+    <div class="liatrio-table-card">
+      <div class="liatrio-card-header">
+        <h2 th:text="#{upcomingVisits}">Upcoming Visits</h2>
+        <p class="liatrio-muted" th:text="|#{upcomingVisits.subtitle} ${days} #{upcomingVisits.days}|"></p>
+      </div>
+
+      <table class="table table-striped liatrio-table">
+        <thead>
+          <tr>
+            <th th:text="#{date}">Date</th>
+            <th th:text="#{pet}">Pet</th>
+            <th th:text="#{owner}">Owner</th>
+            <th th:text="#{description}">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr th:if="${#lists.isEmpty(visits)}">
+            <td colspan="4" th:text="#{upcomingVisits.noResults}">No upcoming visits found.</td>
+          </tr>
+          <tr th:each="v : ${visits}">
+            <td th:text="${#temporals.format(v.date, 'yyyy-MM-dd')}"></td>
+            <td th:text="${v.petName}"></td>
+            <td th:text="${v.ownerFirstName + ' ' + v.ownerLastName}"></td>
+            <td th:text="${v.description}"></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+</body>
+
+</html>

--- a/src/test/java/org/springframework/samples/petclinic/owner/UpcomingVisitsControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/UpcomingVisitsControllerTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.owner;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.aot.DisabledInAotMode;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * Test class for {@link UpcomingVisitsController}.
+ */
+@WebMvcTest(UpcomingVisitsController.class)
+@DisabledInNativeImage
+@DisabledInAotMode
+class UpcomingVisitsControllerTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private VisitRepository visitRepository;
+
+	@Test
+	void testUpcomingVisitsDefaultDays() throws Exception {
+		given(this.visitRepository.findUpcomingWithPetAndOwner(any(), any())).willReturn(List.of());
+
+		this.mockMvc.perform(get("/visits/upcoming"))
+			.andExpect(status().isOk())
+			.andExpect(view().name("visits/upcomingVisits"))
+			.andExpect(model().attributeExists("visits"))
+			.andExpect(model().attribute("days", 7));
+	}
+
+	@Test
+	void testUpcomingVisitsCustomDays() throws Exception {
+		given(this.visitRepository.findUpcomingWithPetAndOwner(any(), any())).willReturn(List.of());
+
+		this.mockMvc.perform(get("/visits/upcoming").param("days", "14"))
+			.andExpect(status().isOk())
+			.andExpect(view().name("visits/upcomingVisits"))
+			.andExpect(model().attributeExists("visits"))
+			.andExpect(model().attribute("days", 14));
+	}
+
+	@Test
+	void testUpcomingVisitsWithVisitData() throws Exception {
+		Owner owner = new Owner();
+		owner.setFirstName("George");
+		owner.setLastName("Franklin");
+		owner.setAddress("110 W. Liberty St.");
+		owner.setCity("Madison");
+		owner.setTelephone("6085551023");
+
+		PetType dog = new PetType();
+		dog.setName("dog");
+
+		Pet pet = new Pet();
+		pet.setName("Leo");
+		pet.setType(dog);
+		pet.setBirthDate(LocalDate.of(2010, 9, 7));
+		owner.addPet(pet);
+		pet.setId(1);
+		pet.setOwner(owner);
+
+		Visit visit = new Visit();
+		visit.setDate(LocalDate.now().plusDays(2));
+		visit.setDescription("Routine checkup");
+		visit.setPet(pet);
+
+		given(this.visitRepository.findUpcomingWithPetAndOwner(any(), any())).willReturn(List.of(visit));
+
+		this.mockMvc.perform(get("/visits/upcoming"))
+			.andExpect(status().isOk())
+			.andExpect(view().name("visits/upcomingVisits"))
+			.andExpect(model().attributeExists("visits"));
+	}
+
+}


### PR DESCRIPTION
## Summary

- Adds a new read-only page at `/visits/upcoming` listing visits scheduled within the next N days (default 7)
- Supports a `?days=` query parameter to control the look-ahead window
- Displays owner name, pet name, date, and description for each upcoming visit
- Uses a JOIN FETCH JPQL query to eagerly load pet and owner in one query (no N+1)

## Changes

### Production code
- `Visit.java` — added `@ManyToOne(LAZY)` back-reference to `Pet` (`insertable=false, updatable=false`)
- `Pet.java` — added `@ManyToOne(LAZY)` back-reference to `Owner` (`insertable=false, updatable=false`)
- `VisitRepository.java` (new) — `JpaRepository<Visit, Integer>` with `findUpcomingWithPetAndOwner` JOIN FETCH query
- `UpcomingVisitView.java` (new) — record DTO carrying date, description, petName, ownerFirstName, ownerLastName
- `UpcomingVisitsController.java` (new) — `@Controller` handling `GET /visits/upcoming`
- `visits/upcomingVisits.html` (new) — Thymeleaf template using existing layout and CSS classes
- `layout.html` — added "Upcoming Visits" navigation menu item
- `messages*.properties` — added `upcomingVisits`, `upcomingVisits.subtitle`, `upcomingVisits.days`, `upcomingVisits.noResults` keys to all 8 locale files

### Tests
- `UpcomingVisitsControllerTests.java` (new) — `@WebMvcTest` with `@MockitoBean`, covers default days, custom days, and visit data rendering
- `e2e-tests/tests/features/upcoming-visits.spec.ts` (new) — Playwright tests: page renders, create a future visit and verify it appears, days param respected

## Test plan

- [x] `./mvnw spring-javaformat:apply` — clean
- [x] `./mvnw test` — 62 tests run, 0 failures, 5 skipped (native/AOT annotations)
- [x] `npm test -- --grep "Upcoming"` — 3 Playwright E2E tests pass
- [x] `GET /visits/upcoming` → 200, view `visits/upcomingVisits`
- [x] `GET /visits/upcoming?days=14` → 200, model attribute `days=14`
- [x] Visit created 2 days in future appears in default upcoming list
- [x] All i18n locale files updated

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Upcoming Visits" page displaying scheduled visits with date, pet name, owner, and description.
  * New navigation menu link for quick access to upcoming visits.
  * Customizable date range filtering (default 7 days).
  * Multi-language support (English, German, Spanish, Persian, Korean, Portuguese, Russian, Turkish).

* **Tests**
  * Added comprehensive end-to-end test coverage for the Upcoming Visits feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->