### PR TITLE
feat: add CSV export endpoint for owner search results

### DIFF
--- a/e2e-tests/tests/features/owner-csv-export.spec.ts
+++ b/e2e-tests/tests/features/owner-csv-export.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@fixtures/base-test';
+import * as path from 'path';
+import * as fs from 'fs';
+
+test.describe('Owner CSV Export', () => {
+  test('downloads CSV with correct headers and data', async ({ page }) => {
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.goto('/owners.csv?lastName=Davis'),
+    ]);
+
+    expect(download.suggestedFilename()).toBe('owners.csv');
+
+    const downloadPath = path.join(__dirname, '../../test-results', 'owners-test.csv');
+    await download.saveAs(downloadPath);
+
+    let content = fs.readFileSync(downloadPath, 'utf8');
+    // Strip BOM if present
+    if (content.charCodeAt(0) === 0xfeff) {
+      content = content.slice(1);
+    }
+
+    const lines = content.trim().split(/\r?\n/);
+    // Header row present
+    expect(lines[0]).toContain('Name');
+    expect(lines[0]).toContain('Telephone');
+    // Data rows present
+    expect(lines.length).toBeGreaterThan(1);
+    expect(content).toContain('Davis');
+
+    fs.unlinkSync(downloadPath);
+  });
+
+  test('returns header row only when no owners match', async ({ page }) => {
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.goto('/owners.csv?lastName=ZZZNoSuchOwner'),
+    ]);
+
+    const downloadPath = path.join(__dirname, '../../test-results', 'owners-empty-test.csv');
+    await download.saveAs(downloadPath);
+
+    let content = fs.readFileSync(downloadPath, 'utf8');
+    if (content.charCodeAt(0) === 0xfeff) {
+      content = content.slice(1);
+    }
+
+    const lines = content
+      .trim()
+      .split(/\r?\n/)
+      .filter((l) => l.trim().length > 0);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe('Name,Address,City,Telephone');
+
+    fs.unlinkSync(downloadPath);
+  });
+});

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>1.14.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
       <optional>true</optional>

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -15,13 +15,20 @@
  */
 package org.springframework.samples.petclinic.owner;
 
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -34,6 +41,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -171,6 +179,31 @@ class OwnerController {
 				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
 		mav.addObject(owner);
 		return mav;
+	}
+
+	@GetMapping("/owners.csv")
+	public void exportOwnersCsv(@RequestParam(defaultValue = "") String lastName, HttpServletResponse response)
+			throws IOException {
+		response.setContentType("text/csv; charset=UTF-8");
+		response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"owners.csv\"");
+		response.getOutputStream().write(new byte[] { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF });
+		Page<Owner> results = this.owners.findByLastNameStartingWith(lastName, Pageable.unpaged());
+		try (CSVPrinter printer = new CSVPrinter(
+				new PrintWriter(new OutputStreamWriter(response.getOutputStream(), StandardCharsets.UTF_8)),
+				CSVFormat.DEFAULT.builder().setHeader("Name", "Address", "City", "Telephone").build())) {
+			for (Owner owner : results) {
+				printer.printRecord(sanitizeForCsv(owner.getFirstName() + " " + owner.getLastName()),
+						sanitizeForCsv(owner.getAddress()), sanitizeForCsv(owner.getCity()),
+						sanitizeForCsv(owner.getTelephone()));
+			}
+		}
+	}
+
+	private static String sanitizeForCsv(String value) {
+		if (value == null) {
+			return "";
+		}
+		return value.replace("\r", "").replace("\n", " ");
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -203,7 +203,11 @@ class OwnerController {
 		if (value == null) {
 			return "";
 		}
-		return value.replace("\r", "").replace("\n", " ");
+		String sanitized = value.replace("\r", "").replace("\n", " ");
+		if (!sanitized.isEmpty() && "=+-@\t".indexOf(sanitized.charAt(0)) >= 0) {
+			sanitized = "'" + sanitized;
+		}
+		return sanitized;
 	}
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -287,6 +287,22 @@ class OwnerControllerTests {
 	}
 
 	@Test
+	void testExportOwnersCsvContainsBom() throws Exception {
+		given(this.owners.findByLastNameStartingWith(anyString(), any(Pageable.class)))
+			.willReturn(new PageImpl<>(List.of(george())));
+
+		byte[] content = mockMvc.perform(get("/owners.csv"))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsByteArray();
+
+		org.assertj.core.api.Assertions.assertThat(content[0]).isEqualTo((byte) 0xEF);
+		org.assertj.core.api.Assertions.assertThat(content[1]).isEqualTo((byte) 0xBB);
+		org.assertj.core.api.Assertions.assertThat(content[2]).isEqualTo((byte) 0xBF);
+	}
+
+	@Test
 	void testExportOwnersCsvEmptyResultReturnsHeaderOnly() throws Exception {
 		given(this.owners.findByLastNameStartingWith(eq("Unknown"), any(Pageable.class)))
 			.willReturn(new PageImpl<>(List.of()));


### PR DESCRIPTION
## Summary
- Adds `GET /owners.csv` endpoint to `OwnerController`
- Respects `lastName` query parameter (same as existing owner search)
- Returns `text/csv; charset=UTF-8` with UTF-8 BOM for Excel compatibility
- Header row: `Name,Address,City,Telephone`
- Uses Apache Commons CSV 1.14.0 for RFC 4180 compliant CSV generation
- Uses `Pageable.unpaged()` to return all results (not paginated)

## Proof / Demo Coverage
- CLI: curl output captured (see below)
- Playwright: E2E test downloads CSV and verifies headers + content

## curl Output
```
curl -s "http://localhost:8080/owners.csv?lastName=Davis"
Name,Address,City,Telephone
Betty Davis,638 Cardinal Ave.,Sun Prairie,6085551749
Harold Davis,563 Friendly St.,Windsor,6085553198

curl -s "http://localhost:8080/owners.csv?lastName=Franklin"
Name,Address,City,Telephone
George Franklin,110 W. Liberty St.,Madison,6085551023

curl -s "http://localhost:8080/owners.csv?lastName=ZZZNoSuchOwner"
Name,Address,City,Telephone
```

## Test plan
- [x] `./mvnw test` passes (all 64 tests pass, 5 skipped for native/AOT)
- [x] New unit tests in `OwnerControllerTests` assert status 200, Content-Type text/csv, header row, lastName filtering, empty result header-only
- [x] Playwright E2E test (`owner-csv-export.spec.ts`) downloads CSV and verifies content
- [x] `spring-javaformat:apply` run before commit
- [x] TDD: RED phase confirmed (5 failing tests), GREEN phase implemented, all tests pass

## Implementation Details

**`OwnerController.java`** — new `exportOwnersCsv` method:
- `@GetMapping("/owners.csv")` with `@RequestParam(defaultValue = "") String lastName`
- Sets `Content-Type: text/csv; charset=UTF-8` and `Content-Disposition: attachment; filename="owners.csv"`
- Writes UTF-8 BOM (0xEF 0xBB 0xBF) for Excel compatibility
- Uses `Pageable.unpaged()` to fetch all matching owners without pagination
- `sanitizeForCsv()` strips CR/LF from field values to prevent CSV injection via newlines

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added owners CSV export via /owners.csv with columns: Name, Address, City, Telephone.
  * Supports filtering by last name, and returns only the header row when no matches.
  * CSV output includes a UTF-8 BOM and proper download headers.

* **Tests**
  * New unit and end-to-end tests validating CSV download, headers, BOM presence, filtering, and empty-result behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->